### PR TITLE
fix: palette-agent binary name is incorrect in install.sh

### DIFF
--- a/install.sh.tmpl
+++ b/install.sh.tmpl
@@ -16,7 +16,7 @@ else
 fi
 
 IMAGE=${IMAGE_REPO}/stylus-agent-mode-linux-${ARCH}:${VERSION}
-URL=${AGENT_URL_PREFIX}/palette-agent-${VERSION}-linux-${ARCH}
+URL=${AGENT_URL_PREFIX}/palette-agent-linux-${ARCH}
 
 # Download edge-agent
 curl -v -L $URL -o palette-agent


### PR DESCRIPTION
Signed-off-by: Nianyu Shen <xiaoyu9964@gmail.com>